### PR TITLE
Always close current connection on QueryExecTimeout to deal with low …

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1505,6 +1505,11 @@ func TestExecWithQueryExecTimeoutSet(t *testing.T) {
 		t.Fatalf("Expected Exec to fail with timeout, instead it failed with '%v'", err)
 	}
 
+	// It should close the timed out connection
+	if !conn1.IsAlive() {
+		t.Fatal("Expected conn1.IsAlive to be false, instead it was true")
+	}
+
 	// case 2: big enough timeout that allows statement to finish.
 	config.QueryExecTimeout = 10 * time.Second
 	conn2 := mustConnect(t, config)

--- a/query.go
+++ b/query.go
@@ -441,6 +441,13 @@ func (c *Conn) Query(sql string, args ...interface{}) (*Rows, error) {
 	}
 	rows.unlockConn = true
 
+	// Set query execution deadline.
+	// Do it before making any write attempts. Otherwise it may hang forever if
+	// there is a connection issue.
+	if timeoutTimer := c.startQueryExecTimeoutTimer(); timeoutTimer != nil {
+		defer timeoutTimer.Stop()
+	}
+
 	ps, ok := c.preparedStatements[sql]
 	if !ok {
 		var err error
@@ -449,11 +456,6 @@ func (c *Conn) Query(sql string, args ...interface{}) (*Rows, error) {
 			rows.abort(err)
 			return rows, rows.err
 		}
-	}
-
-	// Set query execution deadline
-	if timeoutTimer := c.startQueryExecTimeoutTimer(); timeoutTimer != nil {
-		defer timeoutTimer.Stop()
 	}
 
 	rows.fields = ps.FieldDescriptions


### PR DESCRIPTION
…level connection issues.

Otherwise the openned but unusable connection may be aquired and re-used again and again.
There is also a bug fix where we tried to init QueryExecTimeout timer after we tried to write
to the connection (what caused the code to hang if there was a connection issue).

Signed-off-by: konstantin konstantin@rightscale.com
