### PR TITLE
ACL-670 Figure out a way to create closed Rows with their error set.

### DIFF
--- a/query.go
+++ b/query.go
@@ -53,6 +53,11 @@ type Rows struct {
 	closed     bool
 }
 
+// NewErroredRows builds Rows that represent the given error
+func NewErroredRows(err error) *Rows {
+	return &Rows{err: err, closed: true}
+}
+
 func (rows *Rows) FieldDescriptions() []FieldDescription {
 	return rows.fields
 }


### PR DESCRIPTION
One may need to build Rows with error if he implements his own Pool's Query and/or Exec methods.
